### PR TITLE
Fix Powershell colorization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ fn main() {
 
 /// Main function to run the application. Return `std::result::Result<(), std::io::Error>`.
 fn run_app() -> std::result::Result<(), Error> {
+    // Correctly output ANSI escape codes on Windows.
+    #[cfg(windows)]
+    colored::control::set_virtual_terminal(true).ok();
+
     // Parse args using clap.
     let args = Cli::parse();
 


### PR DESCRIPTION
On Windows, Powershell handles ANSI escape codes incorrectly, but `colored` lets you fix that behavior. See https://github.com/mackwic/colored/issues/59

Before:

![image](https://user-images.githubusercontent.com/35764628/163812098-4accdaaf-0e85-451f-ae36-fe43fdd13c12.png)

After:

![image](https://user-images.githubusercontent.com/35764628/163812184-98927429-67cc-4623-9eb3-f133f2cdc5db.png)
