### PR TITLE
Add man page and shell completion generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ target/
 *.pdb
 
 # End of https://www.toptal.com/developers/gitignore/api/rust,linux
+
+# start of personal gitignore
+completions/
+man/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
+dependencies = [
+ "clap 3.1.17",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "clap_mangen"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2ff85c3fa1e7c1a4229f7b4221f769757c3982e2afd3e6d9381d59db2c7e61"
+dependencies = [
+ "clap 3.1.17",
+ "roff",
 ]
 
 [[package]]
@@ -429,6 +448,8 @@ version = "1.1.2"
 dependencies = [
  "atty",
  "clap 3.1.17",
+ "clap_complete",
+ "clap_mangen",
  "cli-clipboard",
  "colored",
  "criterion",
@@ -1505,6 +1526,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 futures-util = "0.3.21"
 phf = { version = "0.10", features = ["macros"] }
 
+[build-dependencies]
+clap_complete = { version = "3.1.4" }
+clap_mangen = { version = "0.1.6" }
+clap = { version = "3.1.10", features = ["derive"] }
+
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.23.1" }
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,35 @@
+use clap::CommandFactory;
+use clap_complete::{
+    generate_to,
+    Shell::{Bash, Elvish, Fish, PowerShell, Zsh},
+};
+use clap_mangen;
+
+// Include the Cli struct.
+include!("src/cli.rs");
+
+fn main() {
+    // Get directories.
+    let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let man_dir = root_dir.join("man");
+    let comp_dir = root_dir.join("completions");
+
+    // Create directories if they don't exist.
+    std::fs::create_dir_all(&man_dir).unwrap();
+    std::fs::create_dir_all(&comp_dir).unwrap();
+
+    // Setup clap command.
+    let mut cmd = Cli::command();
+    cmd.set_bin_name("dym");
+
+    // Generate man page.
+    let man = clap_mangen::Man::new(cmd.to_owned());
+    let mut buffer: Vec<u8> = Default::default();
+    man.render(&mut buffer).expect("Man page generation failed");
+    std::fs::write(man_dir.join("dym.1"), buffer).expect("Failed to write man page");
+
+    // Generate shell completions.
+    for shell in [Bash, Elvish, Fish, PowerShell, Zsh] {
+        generate_to(shell, &mut cmd, "dym", &comp_dir).unwrap();
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,57 @@
+use clap::Parser;
+
+// Parse command line arguments to get the search term.
+#[derive(Parser)]
+#[clap(author = "Hisbaan Noorani", version = "1.1.1", about = "Did You Mean: A cli spelling corrector", long_about = None)]
+pub struct Cli {
+    pub search_term: Option<String>,
+    #[clap(
+        short = 'n',
+        long = "number",
+        default_value_t = 5,
+        help = "Change the number of matches printed",
+        long_help = "Change the number of words the program will print. The default value is five."
+    )]
+    pub number: usize,
+    #[clap(
+        short = 'c',
+        long = "clean-output",
+        help = "Print clean output",
+        long_help = "Print a clean version of the output without the title, numbers or colour."
+    )]
+    pub clean_output: bool,
+    #[clap(
+        short = 'v',
+        long = "verbose",
+        help = "Print verbose output",
+        long_help = "Print verbose output including the edit distance of the found word to the queried word."
+    )]
+    pub verbose: bool,
+    #[clap(
+        short = 'y',
+        long = "yank",
+        help = "Yank (copy) to the system cliboard",
+        long_help = "Yank (copy) the selected word to the system clipboard. If no word is selected, the clipboard will not be altered."
+    )]
+    pub yank: bool,
+    #[clap(
+        short = 'l',
+        long = "lang",
+        help = "Select the desired language using the locale code (en, fr, sp, etc.)",
+        long_help = "Select the desired language using its locale code. For example, English would have the locale code en and French would have the locale code fr. See --print-langs for a list of locale codes and the corresponding languages.",
+        default_value = "en"
+    )]
+    pub lang: String,
+    #[clap(
+        long = "print-langs",
+        help = "Display a list of supported languages",
+        long_help = "Display a list of supported languages and their respective locale codes."
+    )]
+    pub print_langs: bool,
+    #[clap(
+        long = "update-langs",
+        help = "Update all language files",
+        long_help = "Update all language files from the repository https://github.com/hisbaan/wordlists."
+    )]
+    pub update_langs: bool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+pub mod cli;
 pub mod langs;
 pub mod lib;
 
@@ -13,45 +14,10 @@ use std::{
     fs::{create_dir, read_dir, read_to_string, remove_file, File},
     io::{self, BufRead, Error, Write},
 };
-// use tokio;
 
+use cli::Cli;
 use langs::{LOCALES, SUPPORTED_LANGS};
 use lib::{edit_distance, insert_and_shift, yank};
-
-// Parse command line arguments to get the search term.
-#[derive(Parser)]
-#[clap(author = "Hisbaan Noorani", version = "1.1.1", about = "Did You Mean: A cli spelling corrector", long_about = None)]
-struct Cli {
-    search_term: Option<String>,
-    #[clap(
-        short = 'n',
-        long = "number",
-        default_value_t = 5,
-        help = "Change the number of matches printed"
-    )]
-    number: usize,
-    #[clap(short = 'c', long = "clean-output", help = "Print clean output")]
-    clean_output: bool,
-    #[clap(short = 'v', long = "verbose", help = "Print verbose output")]
-    verbose: bool,
-    #[clap(
-        short = 'y',
-        long = "yank",
-        help = "Yank (copy) to the system cliboard"
-    )]
-    yank: bool,
-    #[clap(
-        short = 'l',
-        long = "lang",
-        help = "Select the desired language using the locale code (en, fr, sp, etc.)",
-        default_value = "en"
-    )]
-    lang: String,
-    #[clap(long = "print-langs", help = "Display a list of supported languages")]
-    print_langs: bool,
-    #[clap(long = "update-langs", help = "Update all language files")]
-    update_langs: bool,
-}
 
 fn main() {
     std::process::exit(match run_app() {


### PR DESCRIPTION
Add man pages and shell completions via a `build.rs` build script. This PR also refactors the clap Cli struct into its own file to improve modularity.

closes #8 
closes #9