### PR TITLE
refactor: remove unnecessary library declaration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 pub mod cli;
 pub mod langs;
-pub mod lib;
 
 use clap::Parser;
 use colored::*;
@@ -16,8 +15,8 @@ use std::{
 };
 
 use cli::Cli;
+use didyoumean::{edit_distance, insert_and_shift, yank};
 use langs::{LOCALES, SUPPORTED_LANGS};
-use lib::{edit_distance, insert_and_shift, yank};
 
 fn main() {
     std::process::exit(match run_app() {


### PR DESCRIPTION
This PR fixes the following warning which is shown during `cargo build`:

```
warning: found module declaration for lib.rs
 --> src/main.rs:3:1
  |
3 | pub mod lib;
  | ^^^^^^^^^^^^
  |
  = note: lib.rs is the root of this crate's library target
  = help: to refer to it from other targets, use the library's name as the path
  = note: `#[warn(special_module_name)]` on by default

warning: `didyoumean` (bin "dym") generated 1 warning
```

